### PR TITLE
Support unraid 6.12.11

### DIFF
--- a/Python3.plg
+++ b/Python3.plg
@@ -2,7 +2,7 @@
 <!DOCTYPE PLUGIN [
 <!ENTITY name		"python3">
 <!ENTITY author		"dlandon">
-<!ENTITY version	"2024.07.06">
+<!ENTITY version	"2024.07.17">
 <!ENTITY launch		"">
 <!ENTITY gitURL		"https://raw.githubusercontent.com/&author;/&name;/master">
 <!ENTITY pluginURL	"&gitURL;/Python3.plg">
@@ -17,11 +17,14 @@
 		pluginURL="&pluginURL;"
 		support="&supportURL;"
 		min="6.11.0-rc3;"
-		max="6.12.10">
+		max="6.12.11">
 
 <CHANGES>
 ##&name;
 ###&version;
+- Fix: Set max Unraid version to 6.12.11.
+
+###2024.07.06
 - Fix: Set max Unraid version to 6.12.10.
 
 ###2023.08.01a


### PR DESCRIPTION
After the update to 6.12.11 the python3 plugin was missing from our unraid server.

Tested by installing the updated plugin via https://raw.githubusercontent.com/ap-wtioit/python3/main/Python3.plg on our unraid instance.

Fixes #1 

Info @wt-io-it